### PR TITLE
Add CI workflows, documentation, and PDF generation scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+/.github export-ignore
+/build export-ignore
+/docs export-ignore
+/releases export-ignore
+/scripts export-ignore
+/tests export-ignore
+/vendor export-ignore
+
+/.gitignore export-ignore
+/.phpunit.result.cache export-ignore
+/composer.lock export-ignore
+/phpstan-baseline.neon export-ignore
+/phpstan.neon export-ignore
+/phpunit.xml export-ignore

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,32 @@
+name: PHPStan
+
+on:
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+concurrency:
+  group: phpstan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          coverage: none
+
+      - name: Validate composer.json
+        run: composer validate --no-interaction --no-check-lock
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse -c phpstan.neon --no-progress --memory-limit=1G

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,151 @@
+name: Release
+
+on:
+  push:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Mermaid CLI
+        run: npm install -g @mermaid-js/mermaid-cli
+
+      - name: Install Pandoc and LaTeX
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc texlive-xetex texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended wkhtmltopdf
+
+      - name: Install PDF tooling
+        run: python -m pip install --upgrade pypdf
+
+      - name: Read composer version
+        id: meta
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          data = json.loads(Path("composer.json").read_text(encoding="utf-8"))
+          version = (data.get("version") or "").strip()
+          if not version:
+              raise SystemExit("composer.json is missing a version field.")
+
+          tag = f"v{version}"
+          out = Path(os.environ["GITHUB_OUTPUT"])
+          out.write_text(f"version={version}\ntag={tag}\n", encoding="utf-8")
+          PY
+
+      - name: Check latest release
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+          from pathlib import Path
+
+          repo = os.environ["GITHUB_REPOSITORY"]
+          token = os.environ["GITHUB_TOKEN"]
+          tag = os.environ["RELEASE_TAG"]
+
+          req = urllib.request.Request(
+              f"https://api.github.com/repos/{repo}/releases/latest",
+              headers={
+                  "Authorization": f"Bearer {token}",
+                  "Accept": "application/vnd.github+json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+
+          latest = ""
+          try:
+              with urllib.request.urlopen(req) as r:
+                  data = json.loads(r.read().decode("utf-8"))
+                  latest = data.get("tag_name", "") or ""
+          except urllib.error.HTTPError as e:
+              if e.code != 404:
+                  raise
+
+          should_release = "true" if tag != latest else "false"
+
+          out = Path(os.environ["GITHUB_OUTPUT"])
+          out.write_text(f"latest={latest}\nshould_release={should_release}\n", encoding="utf-8")
+          PY
+
+      - name: Require release notes
+        if: steps.release.outputs.should_release == 'true'
+        id: notes
+        env:
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          version = os.environ["RELEASE_VERSION"]
+          notes = Path("releases") / f"v{version}.md"
+
+          if not notes.is_file():
+              raise SystemExit(
+                  f"Missing release notes: {notes}. "
+                  "Run: python scripts/generate_release_notes.py "
+                  "then fill Description."
+              )
+
+          out = Path(os.environ["GITHUB_OUTPUT"])
+          out.write_text(f"path={notes.as_posix()}\n", encoding="utf-8")
+          PY
+
+      - name: Build PDF
+        if: steps.release.outputs.should_release == 'true'
+        run: python scripts/build_pdf.py --output ways-documentation-${{ steps.meta.outputs.version }}.pdf
+
+      - name: Build source archive
+        if: steps.release.outputs.should_release == 'true'
+        run: |
+          mkdir -p build
+          git archive --format=zip -o build/ways-${{ steps.meta.outputs.version }}.zip HEAD
+
+      - name: Upload artifacts
+        if: steps.release.outputs.should_release == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: |
+            build/ways-${{ steps.meta.outputs.version }}.zip
+            build/ways-documentation-${{ steps.meta.outputs.version }}.pdf
+
+      - name: Create GitHub release
+        if: steps.release.outputs.should_release == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: Div PHP Ways ${{ steps.meta.outputs.version }}
+          body_path: ${{ steps.notes.outputs.path }}
+          files: |
+            build/ways-${{ steps.meta.outputs.version }}.zip
+            build/ways-documentation-${{ steps.meta.outputs.version }}.pdf
+          fail_on_unmatched_files: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          coverage: none
+
+      - name: Validate composer.json
+        run: composer validate --no-interaction --no-check-lock
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run tests
+        run: vendor/bin/phpunit --colors=never

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
 .idea/*
+build/
 example
 vendor
 .vscode
 composer.lock
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.log
+*.cache
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,170 +1,63 @@
 # Div PHP Ways
 
-[![Latest Stable Version](https://poser.pugx.org/divengine/ways/v)](https://packagist.org/packages/divengine/ways) [![Total Downloads](https://poser.pugx.org/divengine/ways/downloads)](https://packagist.org/packages/divengine/ways) [![Latest Unstable Version](https://poser.pugx.org/divengine/ways/v/unstable)](https://packagist.org/packages/divengine/ways) [![License](https://poser.pugx.org/divengine/ways/license)](https://packagist.org/packages/divengine/ways) [![PHP Version Require](https://poser.pugx.org/divengine/ways/require/php)](https://packagist.org/packages/divengine/ways)
+[![Latest Stable Version](https://poser.pugx.org/divengine/ways/v)](https://packagist.org/packages/divengine/ways)
+[![Total Downloads](https://poser.pugx.org/divengine/ways/downloads)](https://packagist.org/packages/divengine/ways)
+[![Latest Unstable Version](https://poser.pugx.org/divengine/ways/v/unstable)](https://packagist.org/packages/divengine/ways)
+[![License](https://poser.pugx.org/divengine/ways/license)](https://packagist.org/packages/divengine/ways)
+[![PHP Version Require](https://poser.pugx.org/divengine/ways/require/php)](https://packagist.org/packages/divengine/ways)
 
-A "way" is different to a "route". We need a path for found a specific resource, but we need a way for do something. This library follow this concept when implements the 
-routing and control of PHP application.
+Div PHP Ways is a small routing and control-flow library for PHP applications. A
+"way" is different from a traditional route: it identifies a control point that
+can execute work, register more control points, exchange data, run hooks, and be
+called from HTTP, CLI, or directly from PHP code.
 
-This class redefines the way PHP applications handle routing and control. Unlike traditional routes, Div PHP Ways introduces the concept of "ways" to execute actions dynamically in a modular and flexible manner.
+## Features
 
-## Key Features
-
-- **Service-Oriented Architecture (SOA):** Adapts SOA principles to PHP applications for enhanced modularity.
-  
-- **Hybrid System Integration:** Seamlessly integrates components in a hybrid system, providing a cohesive architecture.
-
-- **HTTP and CLI Routing:** Acts as a robust router for both HTTP and CLI interfaces, offering a unified approach.
-
-Explore the possibilities with Div PHP Ways and elevate your PHP application architecture to new heights!
-
-## Examples
-
-```php
-<?php
-
-// Registering a closure
-ways::listen("get://home", function($data){
-    echo "Hello {$data['user']}";
-}, "home");
-
-// Adding a hook
-ways::hook(DIV_WAYS_BEFORE_RUN, "home", function($data){
-    $data['user'] = "Peter";
-});
-
-// Listening...
-$data = ways::bootstrap('_url', 'home');
-
-
-
-# Div PHP Ways 2.4.2
-
-
-
-Ways is a class that adapts the concept of SOA to the architecture 
-of a PHP application, and tries to integrate the parts of a hybrid 
-system. 
-
-With Ways you should think more about "control points" 
-than on controllers of an MVC pattern. Control points are 
-activated when they are needed, ie on demand, depending on 
-the definition you have made.
-
-```php
-<?php
-
-ways::listen('sql://...', function($data, $args){
-    
-	ways::listen('sql://query', function($data){
-	  $pdo = new PDO();
-	  $st = $pdo->prepare($data['query']);
-	  $st->execute($data['params']);
-	  $data['result'] = $st->fetchAll(PDO::FETCH_OBJ);
-	  return $data;
-	});
-	
-});
-
-ways::invoke('sql://query', [
-    'query' => 'SELECT * FROM cats WHERE name = ?',
-    'params' => ['Tom']
-]);
-
-```
-
-
-On other platforms it is common to define all routes to 
-the drivers in the same file and once. In Ways this 
-is not an obligation. You can have an initial control 
-point and depending on the URI invoked go to another 
-control point X where routes are defined, so that the 
-path is formed on demand, thus improving performance 
-of its application. The structure of a URI may suggest 
-that Ways allows a hierarchical structure of control points, 
-but it does not, it can create a whole graph structure.
-
-A first URI is invoked, from HTTP or CLI. But inside your code
-you can invoke any URIs
-
-![div ways MVC](https://github.com/divengine/resources/raw/master/div-ways/cards/div-ways-mvc-sample.png)
-
-In addition to this, a control point may require the 
-previous execution of another control point. You can also 
-implement events or hooks, so you can execute one control 
-point before or after another, without the latter knowing 
-the existence of the first. These flexibilities are valid 
-for example in a plugins architecture.
-
-The control points can interact, and this means, redirect 
-the flow to another, call control points directly, exchange 
-data and url arguments, handle the output on screen, etc.
-
-In addition, you can establish rules for the execution of 
-control points.
-
-```php
-<?php
-
-ways::rule('is-monday', function(){
-    return date('D') === 'Mon';
-});
-
-ways::listen('*', function (){
-    echo 'Today is Monday !!!';
-}, [ways::PROPERTY_RULES => ['is-monday']]);
-
-```
-
-Ways is not only intended for the web but also for 
-command line applications. Ways is implemented in a 
-single class, in a single file. This allows quick start-up
-and easy adaptation with other platforms.
-
-## Documentation
-
-Visit https://divengine.org
+- Register closures or class methods as control points.
+- Match HTTP and CLI requests with URL arguments.
+- Invoke ways directly from application code.
+- Attach hooks before include, before run, before output, or after run.
+- Guard control points with reusable rules.
+- Keep the library easy to embed: one class, one source file.
 
 ## Installation
 
-With composer...
+With Composer:
 
 ```bash
 composer require divengine/ways
 ```
 
-Without composer, download the class and...
-
-```php
-include "path/to/divengine/ways.php";
-```
-
-## Basic usage
+Without Composer, include the class directly:
 
 ```php
 <?php
 
-// arbitrary location for software's packages
-define('PACKAGES', 'path/to/app/');
+include "path/to/divengine/ways.php";
+```
+
+## Basic Usage
+
+```php
+<?php
 
 use divengine\ways;
 
-// ways with closure
-ways::listen("get://home", function($data){
-	echo "Hello {$data['user']}";
+ways::listen("get://home", function ($data) {
+    echo "Hello {$data['user']}";
 }, "home");
 
-// add a hook
-ways::hook(DIV_WAYS_BEFORE_RUN, "home", function($data){
-	$data['user'] = "Peter";
+ways::hook(DIV_WAYS_BEFORE_RUN, "home", function ($data) {
+    $data['user'] = "Peter";
+    return $data;
 });
 
-// listen... 
-$data = ways::bootstrap('_url', 'home');
+$data = ways::bootstrap("_url", "home");
 ```
 
-## Call a static method
+## Static Method Controllers
 
-**app/control/Home.php**
+`ways::register()` can read controller metadata from PHP comments.
 
 ```php
 <?php
@@ -172,114 +65,87 @@ $data = ways::bootstrap('_url', 'home');
 #id = home
 #listen = /home
 
-class Home {
-	
-	static function Run()
-	{
-	    echo "Hello world";
-	}
-		
-	static function About()
-	{
-		echo "About us";
-	}
-	
-	#listen@Contact = get://about
-	static function Contact()
-	{
-		echo "Contact us";
-	}
+class Home
+{
+    public static function Run()
+    {
+        echo "Hello world";
+    }
+
+    public static function About()
+    {
+        echo "About us";
+    }
+
+    #listen@Contact = get://contact
+    public static function Contact()
+    {
+        echo "Contact us";
+    }
 }
 ```
 
-**index.php**
 ```php
 <?php
 
-// register a controller with the default static method ::Run()
-ways::register("app/control/Home.php");
+use divengine\ways;
 
-// route to another static method ([controllerID]@[method])
+ways::register("app/control/Home.php");
 ways::listen("/about", "home@About");
 
-// route to closure
-ways::listen("/sayMeHello/{name}", function($data, $args) {
-	echo "Hello {$args['name']}";	
-});
-
-// hook on the fly
-ways::hook(DIV_WAYS_BEFORE_RUN, 
-	ways::listen("/tests/...", function(){
-		
-		ways::listen("/tests/1", function(){
-			echo "This is the test 1";
-		}); 	
-		
-		ways::listen("/tests/2", function(){
-			echo "This is the test 2";
-		});
-		
-		if (ways::match("/tests/3")) {
-			echo "This is the test 3";
-		}
-		
-		ways::bootstrap();
-	}), 
-	function(){
-		if (!isset($_SESSION['user']))
-		{
-			echo "You are not a tester";
-			return false;
-		}
-		return true;
-	});
-
-// route to a static method
 ways::bootstrap("_url", "home");
 ```
 
-**.htaccess**
-```apacheconfig
-RewriteEngine On
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule ^((?s).*)$ index.php?_url=/$1 [QSA,L]
-```
-# CLI app
+## Rules
+
+Rules can prevent execution when a condition is not met.
 
 ```php
 <?php
 
-// say me hello
-// $ php one_script.php hello Peter
-ways::listen("/hello/{name}", function ($data = [], $args = []) {
-	echo "Hello {$args['name']}\n";
+use divengine\ways;
+
+ways::rule("is-admin-section", function ($data, $args) {
+    return $args["section"] === "admin";
 });
+
+ways::listen("/{section}/login", function () {
+    echo "admin login";
+}, [
+    ways::PROPERTY_RULES => ["is-admin-section"],
+]);
 ```
 
-# Get controller properties
+## CLI
+
+Ways also works from command line scripts.
 
 ```php
 <?php
 
-$property = "This is a property value";
+use divengine\ways;
 
-ways::listen("/", function ($data = [], $args = [], $properties = []) {
-	echo "Controller ID = " . $properties['id'] . "\n";
-	echo "A controller property = " . $properties['myProperty'];
+ways::listen("/hello/{name}", function ($data = [], $args = []) {
+    echo "Hello {$args['name']}\n";
+});
 
-}, [
-	'myProperty' => $property,
-]);
-
+ways::bootstrap();
 ```
 
-Enjoy!
+```bash
+php one_script.php hello Peter
+```
 
--- 
+## Documentation
 
-@rafageist
+The Markdown documentation lives in `docs/`. Release builds generate a PDF with
+`scripts/build_pdf.py`.
 
-Eng. Rafa Rodriguez
+## License
 
+GPL-3.0-or-later.
+
+--
+
+Rafa Rodriguez  
 https://rafageist.com

--- a/docs/Div PHP Ways.md
+++ b/docs/Div PHP Ways.md
@@ -1,7 +1,7 @@
 [![Readme Card](https://github-readme-stats.vercel.app/api/pin/?username=divengine&repo=ways&show_owner=true&rand=23)](https://github.com/anuraghazra/github-readme-stats)
 
 [[Introduction to Div PHP Ways]]
-[[Documentation/Div PHP Ways/Getting started]]
+[[Getting started]]
 [[Call a static method]]
 [[CLI app]]
 [[Get controller properties]]

--- a/docs/book-order.txt
+++ b/docs/book-order.txt
@@ -1,0 +1,6 @@
+docs/Div PHP Ways.md
+docs/Introduction to Div PHP Ways.md
+docs/Getting started.md
+docs/Call a static method.md
+docs/CLI app.md
+docs/Get controller properties.md

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+	level: 4
+	paths:
+		- src
+		- tests
+	treatPhpDocTypesAsCertain: false

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+	executionOrder="depends,defects"
+	failOnRisky="true"
+	displayDetailsOnTestsThatTriggerWarnings="true"
+	failOnWarning="true"
+	colors="true">
+	<testsuites>
+		<testsuite name="divengine/ways">
+			<directory>tests</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/releases/README.md
+++ b/releases/README.md
@@ -1,0 +1,18 @@
+# Release Notes
+
+Each release must have a markdown file in this folder named `v<version>.md`,
+where `<version>` matches the `version` in `composer.json`.
+
+To generate a draft with the deterministic sections, run:
+
+```bash
+python scripts/generate_release_notes.py
+```
+
+This draft includes:
+- Description placeholder (preserved if already written)
+- Commit subjects since the last tag
+
+If the file already exists, the generator regenerates everything but preserves
+the `## Description` section verbatim. The release workflow will fail if the
+file is missing.

--- a/releases/v2.5.0.md
+++ b/releases/v2.5.0.md
@@ -1,0 +1,15 @@
+# Release v2.5.0
+Date: 2026-05-01
+
+## Description
+Release focused on preparing Div PHP Ways for a maintained package workflow.
+It adds project-specific CI checks, PHPStan configuration, PHPUnit coverage for
+core routing behavior, release note generation, and the documentation PDF
+pipeline adapted from the Div tooling to the Ways package.
+
+## Commits
+- [Add documentation for CLI app, static method usage, and controller properties](https://github.com/divengine/ways/commit/ed28ef1da6138e7bf2e1bbd632e9820f28ea02f5)
+- [Update README.md with new website link and formatting improvements](https://github.com/divengine/ways/commit/30e38775c3aaab7aa2331ddd6e9225149d1c5bbb)
+- [Fixing some deprecated warnings](https://github.com/divengine/ways/commit/b292ad0bdf31eb058a0b917f75cec449945c907e)
+- [Starting 3.0.0](https://github.com/divengine/ways/commit/731e2b9d989a3b4d773f101e7d610cfe7202354a)
+- [Update README.md](https://github.com/divengine/ways/commit/53bf79b31eb9ec0a1775af5ea38e752290074f47)

--- a/releases/v2.5.0.md
+++ b/releases/v2.5.0.md
@@ -5,7 +5,7 @@ Date: 2026-05-01
 Release focused on preparing Div PHP Ways for a maintained package workflow.
 It adds project-specific CI checks, PHPStan configuration, PHPUnit coverage for
 core routing behavior, release note generation, and the documentation PDF
-pipeline adapted from the Div tooling to the Ways package.
+pipeline.
 
 ## Commits
 - [Add documentation for CLI app, static method usage, and controller properties](https://github.com/divengine/ways/commit/ed28ef1da6138e7bf2e1bbd632e9820f28ea02f5)

--- a/scripts/back.html
+++ b/scripts/back.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Div PHP Ways - Back</title>
+  <style>
+    @page {
+      size: {{page_size}};
+      margin: 0;
+    }
+
+    :root {
+      --ink: #0f172a;
+      --muted: #475569;
+      --accent: #0ea5e9;
+      --paper: #f8fafc;
+    }
+
+    html, body {
+      height: 100%;
+    }
+
+    body {
+      margin: 0;
+      background: var(--paper);
+      color: var(--ink);
+      font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    }
+
+    .page {
+      width: 210mm;
+      height: 297mm;
+      position: relative;
+      overflow: hidden;
+      background:
+        linear-gradient(0deg, rgba(15,23,42,0.04) 0%, rgba(15,23,42,0.0) 45%),
+        var(--paper);
+      padding: 28mm 24mm 22mm 24mm;
+      box-sizing: border-box;
+    }
+
+    .title {
+      font-family: "Georgia", "Times New Roman", serif;
+      font-size: 20pt;
+      margin-bottom: 10mm;
+    }
+
+    .summary {
+      font-size: 11pt;
+      line-height: 1.6;
+      color: var(--muted);
+      max-width: 150mm;
+    }
+
+    .list {
+      margin: 12mm 0 0 0;
+      padding-left: 5mm;
+      color: var(--muted);
+      font-size: 10.5pt;
+      line-height: 1.6;
+    }
+
+    .footer {
+      position: absolute;
+      bottom: 18mm;
+      left: 24mm;
+      right: 24mm;
+      display: flex;
+      justify-content: space-between;
+      font-size: 9.5pt;
+      color: var(--muted);
+      border-top: 1px solid rgba(15, 23, 42, 0.15);
+      padding-top: 6mm;
+    }
+
+    .accent {
+      position: absolute;
+      top: -20mm;
+      right: -40mm;
+      width: 120mm;
+      height: 120mm;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(14,165,233,0.12) 0%, rgba(14,165,233,0.0) 70%);
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div class="accent"></div>
+    <div class="title">About this documentation</div>
+    <div class="summary">
+      This book documents Div PHP Ways: its routing model, controller registration,
+      hooks, rules, direct invocation, and CLI support. Ways treats application
+      entry points as control points that can be composed on demand for web and
+      command line applications.
+    </div>
+    <ul class="list">
+      <li>Conceptual overview of ways and control points</li>
+      <li>Installation and basic usage</li>
+      <li>Closure and static method controllers</li>
+      <li>Hooks, rules, data flow, and arguments</li>
+      <li>HTTP and CLI routing examples</li>
+    </ul>
+    <div class="footer">
+      <div>{{org}}</div>
+      <div>Version {{version}} - {{date}}</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/scripts/build_pdf.py
+++ b/scripts/build_pdf.py
@@ -1,0 +1,456 @@
+import argparse
+import html
+import json
+import os
+import re
+import shutil
+import subprocess
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS_DIR = ROOT / "docs"
+BUILD_DIR = ROOT / "build"
+MERMAID_DIR = BUILD_DIR / "mermaid"
+
+
+def collect_markdown_files():
+    files = sorted(DOCS_DIR.rglob("*.md"))
+    readme = DOCS_DIR / "README.md"
+    if readme in files:
+        files.remove(readme)
+        files.insert(0, readme)
+    return files
+
+
+def read_order_file(order_path: Path):
+    files = []
+    for raw_line in order_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        path = (ROOT / line).resolve()
+
+        if line.endswith("/") or path.is_dir():
+            for md in sorted(path.rglob("*.md")):
+                files.append(md)
+            continue
+
+        if path.is_file():
+            files.append(path)
+
+    return files
+
+
+def slugify(text: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return slug or "section"
+
+
+def build_wiki_link_map(files):
+    link_map = {}
+    anchors = {}
+    for path in files:
+        stem = path.stem
+        anchor = slugify(stem)
+        anchors[path] = anchor
+        link_map[stem] = anchor
+        link_map[f"{stem}.md"] = anchor
+        rel = path.relative_to(DOCS_DIR).as_posix()
+        link_map[rel] = anchor
+        if rel.endswith(".md"):
+            link_map[rel[:-3]] = anchor
+    return link_map, anchors
+
+
+def heading_shift_for_path(path: Path) -> int:
+    stem = path.stem
+    match = re.match(r"^(\d+(?:\.\d+)*)", stem)
+    if not match:
+        return 0
+    depth = len(match.group(1).split("."))
+    return max(0, depth - 1)
+
+
+def shift_heading_levels(content: str, shift: int) -> str:
+    if shift <= 0:
+        return content
+
+    lines = content.splitlines()
+    out = []
+    in_fence = False
+    for line in lines:
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            out.append(line)
+            continue
+
+        if not in_fence:
+            match = re.match(r"^(#{1,6})(\s+.*)$", line)
+            if match:
+                level = len(match.group(1))
+                new_level = min(6, level + shift)
+                out.append("#" * new_level + match.group(2))
+                continue
+
+        out.append(line)
+
+    return "\n".join(out)
+
+
+def format_section_number(parts: list[int]) -> str:
+    if len(parts) == 1:
+        return f"{parts[0]}."
+    return ".".join(str(part) for part in parts)
+
+
+def renumber_headings(content: str, base_nums: list[int]) -> str:
+    if not base_nums:
+        return content
+
+    lines = content.splitlines()
+    out = []
+    in_fence = False
+    base_level = None
+    counters: list[int] = []
+
+    for line in lines:
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            out.append(line)
+            continue
+
+        if in_fence:
+            out.append(line)
+            continue
+
+        match = re.match(r"^(#{1,6})\s+(.*)$", line)
+        if not match:
+            out.append(line)
+            continue
+
+        level = len(match.group(1))
+        title = match.group(2).strip()
+        title = re.sub(r"^\d+(?:\.\d+)*\.?\s+", "", title)
+
+        if base_level is None:
+            base_level = level
+
+        if level < base_level:
+            base_level = level
+            counters = []
+
+        relative = level - base_level
+        if relative <= 0:
+            number_parts = base_nums
+            counters = []
+        else:
+            idx = relative - 1
+            if len(counters) <= idx:
+                counters.extend([0] * (idx + 1 - len(counters)))
+            counters[idx] += 1
+            for reset_idx in range(idx + 1, len(counters)):
+                counters[reset_idx] = 0
+            number_parts = base_nums + counters[: relative]
+
+        number_text = format_section_number(number_parts)
+        out.append(f"{match.group(1)} {number_text} {title}")
+
+    return "\n".join(out)
+
+
+def combine_markdown(files, anchors):
+    parts = []
+    for idx, path in enumerate(files):
+        content = path.read_text(encoding="utf-8")
+        content = shift_heading_levels(content, heading_shift_for_path(path))
+        match = re.match(r"^(\d+(?:\.\d+)*)", path.stem)
+        base_nums = [int(part) for part in match.group(1).split(".")] if match else []
+        content = renumber_headings(content, base_nums)
+        anchor = anchors.get(path)
+        if anchor:
+            parts.append(f"\n\n\\hypertarget{{{anchor}}}{{}}\n\n")
+        parts.append(content)
+        parts.append("\n\n\\newpage\n\n")
+    return "".join(parts).strip() + "\n"
+
+
+def render_mermaid(markdown, mermaid_cli, puppeteer_config):
+    pattern = re.compile(r"```mermaid\s*(.*?)```", re.S)
+    MERMAID_DIR.mkdir(parents=True, exist_ok=True)
+    counter = 0
+
+    def repl(match):
+        nonlocal counter
+        counter += 1
+        code = match.group(1).strip() + "\n"
+        mmd_path = MERMAID_DIR / f"diagram_{counter}.mmd"
+        png_path = MERMAID_DIR / f"diagram_{counter}.png"
+        mmd_path.write_text(code, encoding="utf-8")
+
+        cmd = [mermaid_cli, "-i", str(mmd_path), "-o", str(png_path)]
+        if puppeteer_config:
+            cmd.extend(["-p", str(puppeteer_config)])
+
+        subprocess.run(cmd, check=True)
+        return f"![]({png_path.as_posix()})"
+
+    return pattern.sub(repl, markdown)
+
+
+def sanitize_markdown_for_pdf(markdown: str, wiki_links: dict[str, str]) -> str:
+    # Drop Obsidian-style embedded images and convert remote images to links.
+    markdown = re.sub(r"!\[\[([^\]]+)\]\]", r"Image: \1", markdown)
+
+    def replace_remote_image(match):
+        alt = (match.group(1) or "").strip()
+        url = match.group(2).strip()
+        label = alt if alt else url
+        return f"[{label}]({url})"
+
+    markdown = re.sub(r"!\[([^\]]*)\]\((https?://[^)]+)\)", replace_remote_image, markdown)
+
+    # Protect fenced code blocks, inline code, and raw LaTeX commands we inject.
+    code_blocks = []
+    inline_codes = []
+    latex_lines = []
+
+    def protect(pattern, text, bucket, token):
+        def repl(match):
+            bucket.append(match.group(0))
+            return f"{token}{len(bucket) - 1}@@"
+
+        return re.sub(pattern, repl, text, flags=re.S | re.M)
+
+    markdown = protect(r"```.*?```", markdown, code_blocks, "@@CODEBLOCK")
+    markdown = protect(r"`[^`]*`", markdown, inline_codes, "@@CODEINLINE")
+    markdown = protect(
+        r"^\\(?:newpage|tableofcontents|hypertarget\{[^}]+\}\{\}|thispagestyle\{[^}]+\}|begin\{center\}|end\{center\}|vspace\*?\{[^}]+\}|vfill|rule\{[^}]+\}\{[^}]+\}|Huge|LARGE|Large|large|normalsize|bfseries)\s*$",
+        markdown,
+        latex_lines,
+        "@@LATEXLINE",
+    )
+
+    # Convert wiki-style links to internal anchors when possible.
+    # Supports [[Page]] and [[Page|Label]].
+    def replace_wiki_link(match):
+        target = (match.group(1) or "").strip()
+        label = (match.group(2) or "").strip()
+        if not target:
+            return ""
+        anchor = wiki_links.get(target)
+        display = label if label else target
+        if anchor:
+            return f"[{display}](#{anchor})"
+        return display
+
+    markdown = re.sub(r"\[\[([^\]|]+?)(?:\|([^\]]+?))?\]\]", replace_wiki_link, markdown)
+
+    # Escape stray backslashes so LaTeX doesn't treat them as commands.
+    markdown = markdown.replace("\\", "\\textbackslash{}")
+    # Escape dollar signs to avoid Pandoc math parsing.
+    markdown = markdown.replace("$", "\\$")
+
+    def restore(text, bucket, token):
+        for idx, original in enumerate(bucket):
+            text = text.replace(f"{token}{idx}@@", original)
+        return text
+
+    markdown = restore(markdown, latex_lines, "@@LATEXLINE")
+    markdown = restore(markdown, inline_codes, "@@CODEINLINE")
+    markdown = restore(markdown, code_blocks, "@@CODEBLOCK")
+
+    return markdown
+
+
+def build_pdf(input_md, output_pdf, paper_size: str):
+    cmd = [
+        "pandoc",
+        str(input_md),
+        "-o",
+        str(output_pdf),
+        "--pdf-engine=xelatex",
+        "-V",
+        f"papersize={paper_size}",
+        "-V",
+        "geometry:left=0.7in,right=0.7in,top=0.9in,bottom=0.9in",
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def render_html_template(template_path: Path, output_path: Path, context: dict[str, str]) -> None:
+    raw = template_path.read_text(encoding="utf-8")
+    for key, value in context.items():
+        raw = raw.replace(f"{{{{{key}}}}}", html.escape(value))
+    output_path.write_text(raw, encoding="utf-8", newline="\n")
+
+
+def render_html_to_pdf(html_path: Path, pdf_path: Path) -> None:
+    try:
+        from weasyprint import HTML  # type: ignore
+    except Exception:
+        HTML = None
+
+    if HTML is not None:
+        HTML(filename=str(html_path)).write_pdf(str(pdf_path))
+        return
+
+    wkhtmltopdf = shutil.which("wkhtmltopdf")
+    if wkhtmltopdf:
+        subprocess.run([wkhtmltopdf, "--quiet", str(html_path), str(pdf_path)], check=True)
+        return
+
+    raise RuntimeError(
+        "HTML-to-PDF renderer not found. Install weasyprint (pip install weasyprint) "
+        "or wkhtmltopdf to render cover/back templates."
+    )
+
+
+def merge_pdfs(output_pdf: Path, parts: list[Path]) -> None:
+    try:
+        from pypdf import PdfReader, PdfWriter  # type: ignore
+    except Exception:
+        try:
+            from PyPDF2 import PdfReader, PdfWriter  # type: ignore
+        except Exception as exc:
+            raise SystemExit(
+                "PDF merger not available. Install pypdf (pip install pypdf) "
+                "or remove cover/back templates."
+            ) from exc
+
+    writer = PdfWriter()
+    for part in parts:
+        if not part.exists():
+            continue
+        reader = PdfReader(str(part))
+        for page in reader.pages:
+            writer.add_page(page)
+    with output_pdf.open("wb") as handle:
+        writer.write(handle)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", default="ways-documentation.pdf")
+    parser.add_argument("--no-mermaid", action="store_true")
+    parser.add_argument("--order-file", default="docs/book-order.txt")
+    parser.add_argument(
+        "--paper-size",
+        default="letter",
+        help="Paper size for PDF output (e.g., letter, a4).",
+    )
+    args = parser.parse_args()
+
+    BUILD_DIR.mkdir(exist_ok=True)
+
+    order_path = (ROOT / args.order_file).resolve()
+    if order_path.is_file():
+        files = read_order_file(order_path)
+    else:
+        files = collect_markdown_files()
+    if not files:
+        raise SystemExit("No markdown files found under docs/")
+
+    version = ""
+    composer = ROOT / "composer.json"
+    if composer.is_file():
+        data = json.loads(composer.read_text(encoding="utf-8"))
+        version = (data.get("version") or "").strip()
+
+    title = "Div PHP Ways"
+    subtitle = "Routing and control flow for PHP applications"
+    author = "Rafa Rodríguez (@rafageist)"
+    org = "Divengine Software Solutions (divengine.com)"
+    today = date.today().isoformat()
+    cover_lines = [
+        "\\tableofcontents",
+        "\\newpage",
+        "",
+    ]
+
+    wiki_links, anchors = build_wiki_link_map(files)
+    combined = "\n".join(cover_lines) + combine_markdown(files, anchors)
+    combined = sanitize_markdown_for_pdf(combined, wiki_links)
+
+    mermaid_cli = os.environ.get("MERMAID_CLI", "mmdc")
+    if os.name == "nt":
+        # Prefer the .cmd shim on Windows; the extensionless file may not be executable.
+        if mermaid_cli.lower() in {"mmdc", "mmdc.exe"}:
+            mermaid_cli = "mmdc.cmd"
+        else:
+            cli_path = Path(mermaid_cli)
+            if cli_path.name.lower() == "mmdc" and cli_path.suffix == "":
+                mermaid_cli = str(cli_path.with_suffix(".cmd"))
+
+    resolved_cli = shutil.which(mermaid_cli)
+    if resolved_cli:
+        mermaid_cli = resolved_cli
+    elif not args.no_mermaid:
+        raise SystemExit(
+            "Mermaid CLI not found. Install @mermaid-js/mermaid-cli or run with --no-mermaid."
+        )
+    puppeteer_config = ROOT / "scripts" / "puppeteer.json"
+    if args.no_mermaid:
+        rendered = combined
+    else:
+        rendered = render_mermaid(combined, mermaid_cli, puppeteer_config)
+
+    book_md = BUILD_DIR / "book.md"
+    book_md.write_text(rendered, encoding="utf-8", newline="\n")
+
+    output_pdf = BUILD_DIR / args.output
+    build_pdf(book_md, output_pdf, args.paper_size)
+
+    cover_template = ROOT / "scripts" / "cover.html"
+    back_template = ROOT / "scripts" / "back.html"
+    use_cover = cover_template.is_file()
+    use_back = back_template.is_file()
+    if use_cover or use_back:
+        paper_size = args.paper_size.strip()
+        if paper_size.lower().startswith("a") and len(paper_size) <= 3:
+            css_paper = paper_size.upper()
+        else:
+            css_paper = paper_size.lower()
+
+        context = {
+            "title": title,
+            "subtitle": subtitle,
+            "author": author,
+            "org": org,
+            "version": version if version else "unknown",
+            "date": today,
+            "page_size": css_paper,
+        }
+        parts = []
+
+        if use_cover:
+            cover_html = BUILD_DIR / "cover.html"
+            cover_pdf = BUILD_DIR / "cover.pdf"
+            render_html_template(cover_template, cover_html, context)
+            try:
+                render_html_to_pdf(cover_html, cover_pdf)
+                parts.append(cover_pdf)
+            except RuntimeError as exc:
+                print(f"Skipping cover PDF: {exc}")
+
+        parts.append(output_pdf)
+
+        if use_back:
+            back_html = BUILD_DIR / "back.html"
+            back_pdf = BUILD_DIR / "back.pdf"
+            render_html_template(back_template, back_html, context)
+            try:
+                render_html_to_pdf(back_html, back_pdf)
+                parts.append(back_pdf)
+            except RuntimeError as exc:
+                print(f"Skipping back PDF: {exc}")
+
+        if len(parts) > 1:
+            merged_pdf = BUILD_DIR / f"merged-{args.output}"
+            merge_pdfs(merged_pdf, parts)
+            merged_pdf.replace(output_pdf)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cover.html
+++ b/scripts/cover.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Div PHP Ways - Cover</title>
+  <style>
+    @page {
+      size: {{page_size}};
+      margin: 0;
+    }
+
+    :root {
+      --ink: #0b1b2b;
+      --muted: #4b5563;
+      --accent: #111827;
+      --accent-dark: #1f2937;
+      --paper: #ffffff;
+      --stripe: rgba(0, 0, 0, 0.18);
+      --stripe-light: rgba(0, 0, 0, 0.06);
+    }
+
+    html, body {
+      height: 100%;
+    }
+
+    body {
+      margin: 0;
+      background: var(--paper);
+      color: var(--ink);
+      font-family: "Georgia", "Times New Roman", serif;
+    }
+
+    .page {
+      width: 210mm;
+      height: 297mm;
+      position: relative;
+      overflow: hidden;
+      background:
+        radial-gradient(circle at 20% 20%, rgba(15,23,42,0.06), transparent 45%),
+        radial-gradient(circle at 70% 80%, rgba(15,23,42,0.04), transparent 55%),
+        var(--paper);
+    }
+
+    .band {
+      position: absolute;
+      top: 36mm;
+      left: -10mm;
+      right: -10mm;
+      height: 40mm;
+      background: linear-gradient(90deg, rgba(15,23,42,0.12), rgba(15,23,42,0.02));
+      transform: skewY(-4deg);
+      opacity: 1;
+    }
+
+    .stripes {
+      position: absolute;
+      top: 0;
+      right: -20mm;
+      width: 90mm;
+      height: 100%;
+      background: repeating-linear-gradient(
+        120deg,
+        var(--stripe) 0px,
+        var(--stripe) 16px,
+        var(--stripe-light) 16px,
+        var(--stripe-light) 32px
+      );
+      opacity: 0.65;
+    }
+
+    .content {
+      position: relative;
+      padding: 42mm 22mm 24mm 22mm;
+      z-index: 2;
+    }
+
+    .title {
+      font-size: 68pt;
+      letter-spacing: 0.06em;
+      font-weight: 700;
+      margin: 0;
+      color: var(--ink);
+    }
+
+    .subtitle {
+      font-size: 19pt;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      margin: 6mm 0 0 0;
+      color: var(--muted);
+      font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    }
+
+    .rule {
+      width: 78mm;
+      height: 2px;
+      background: rgba(15,23,42,0.5);
+      margin: 16mm 0 12mm 0;
+    }
+
+    .meta {
+      font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      font-size: 11pt;
+      line-height: 1.6;
+      color: var(--muted);
+    }
+
+    .meta strong {
+      color: var(--ink);
+      font-weight: 600;
+    }
+
+    .corner {
+      position: absolute;
+      bottom: 18mm;
+      right: 18mm;
+      width: 70mm;
+      height: 70mm;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(15,23,42,0.08) 0%, rgba(15,23,42,0.0) 70%);
+    }
+
+    .illustration {
+      position: absolute;
+      left: 18mm;
+      bottom: 26mm;
+      width: 80mm;
+      height: 70mm;
+      opacity: 0.9;
+    }
+
+    .illustration svg {
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div class="band"></div>
+    <div class="stripes"></div>
+    <div class="content">
+      <h1 class="title">Ways</h1>
+      <div class="subtitle">Routing and control flow for PHP</div>
+      <div class="rule"></div>
+      <div class="meta">
+        <div><strong>Author:</strong> {{author}}</div>
+        <div><strong>Organization:</strong> {{org}}</div>
+        <div><strong>Version:</strong> {{version}}</div>
+        <div><strong>Generated:</strong> {{date}}</div>
+      </div>
+    </div>
+    <div class="illustration">
+      <svg viewBox="0 0 400 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M45 70h120c35 0 35 55 70 55h120" stroke="rgba(15,23,42,0.5)" stroke-width="8" stroke-linecap="round"/>
+        <path d="M45 150h95c45 0 45-50 95-50h120" stroke="rgba(15,23,42,0.28)" stroke-width="8" stroke-linecap="round"/>
+        <path d="M45 220h120c35 0 35-45 70-45h120" stroke="rgba(15,23,42,0.38)" stroke-width="8" stroke-linecap="round"/>
+        <circle cx="45" cy="70" r="18" fill="rgba(15,23,42,0.10)" stroke="rgba(15,23,42,0.45)" stroke-width="2"/>
+        <circle cx="355" cy="125" r="18" fill="rgba(15,23,42,0.10)" stroke="rgba(15,23,42,0.45)" stroke-width="2"/>
+        <circle cx="45" cy="150" r="18" fill="rgba(15,23,42,0.08)" stroke="rgba(15,23,42,0.35)" stroke-width="2"/>
+        <circle cx="355" cy="100" r="18" fill="rgba(15,23,42,0.08)" stroke="rgba(15,23,42,0.35)" stroke-width="2"/>
+        <circle cx="45" cy="220" r="18" fill="rgba(15,23,42,0.10)" stroke="rgba(15,23,42,0.45)" stroke-width="2"/>
+        <circle cx="355" cy="175" r="18" fill="rgba(15,23,42,0.10)" stroke="rgba(15,23,42,0.45)" stroke-width="2"/>
+      </svg>
+    </div>
+    <div class="corner"></div>
+  </div>
+</body>
+</html>

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -1,0 +1,200 @@
+import argparse
+import json
+import re
+import subprocess
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_git(args):
+    result = subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def get_version():
+    data = json.loads((ROOT / "composer.json").read_text(encoding="utf-8"))
+    version = (data.get("version") or "").strip()
+    if not version:
+        raise SystemExit("composer.json is missing a version field.")
+    return version
+
+
+def get_last_tag():
+    return run_git(["describe", "--tags", "--abbrev=0"])
+
+
+def parse_version(value: str):
+    value = value.strip()
+    if value.startswith("v"):
+        value = value[1:]
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)$", value)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def list_release_note_versions():
+    releases_dir = ROOT / "releases"
+    if not releases_dir.is_dir():
+        return []
+    versions = []
+    for path in releases_dir.glob("v*.md"):
+        version = parse_version(path.stem)
+        if version:
+            versions.append(version)
+    return versions
+
+
+def get_previous_release_version(current_version: str):
+    current = parse_version(current_version)
+    if not current:
+        return None
+    candidates = [v for v in list_release_note_versions() if v < current]
+    if not candidates:
+        return None
+    return max(candidates)
+
+
+def format_version(version_tuple):
+    return ".".join(str(part) for part in version_tuple)
+
+
+def tag_exists(tag: str) -> bool:
+    output = run_git(["tag", "--list", tag])
+    return bool(output.strip())
+
+
+def get_base_from_previous_notes(version_tuple):
+    if not version_tuple:
+        return None
+    filename = f"v{format_version(version_tuple)}.md"
+    path = ROOT / "releases" / filename
+    if not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8").replace("\r\n", "\n")
+    match = re.search(r"^## Commits\s*$\n(?P<body>.*?)(?=^## |\Z)", text, re.M | re.S)
+    if not match:
+        return None
+    for line in match.group("body").splitlines():
+        line = line.strip()
+        if not line.startswith("-"):
+            continue
+        commit_match = re.search(r"/commit/([0-9a-f]{7,40})", line)
+        if commit_match:
+            return commit_match.group(1)
+    return None
+
+
+def get_commits(base, head):
+    log = run_git(["log", "--pretty=format:%H\t%s", f"{base}..{head}"])
+    rows = []
+    for line in log.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if "\t" in line:
+            sha, subject = line.split("\t", 1)
+        else:
+            sha, subject = line, ""
+        subject = subject.strip()
+        if not subject:
+            continue
+        subject_lower = subject.lower()
+        if subject_lower.startswith("merge"):
+            continue
+        if subject_lower.startswith("update changelog"):
+            continue
+        if len(subject.split()) <= 1:
+            continue
+        rows.append((sha, subject))
+    return rows
+
+
+def load_existing_description_block(path: Path):
+    if not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8").replace("\r\n", "\n")
+    match = re.search(r"^## Description\s*$\n(?P<desc>.*?)(?=^## |\Z)", text, re.M | re.S)
+    if not match:
+        return None
+    return match.group(0).rstrip("\n")
+
+
+def build_notes(version, base, head, description_block):
+    today = date.today().isoformat()
+    commits = get_commits(base, head)
+
+    lines = []
+    lines.append(f"# Release v{version}")
+    lines.append(f"Date: {today}")
+    lines.append("")
+    if description_block:
+        lines.extend(description_block.splitlines())
+    else:
+        lines.append("## Description")
+        lines.append("TODO: Add release description.")
+    lines.append("")
+
+    lines.append("## Commits")
+    if commits:
+        for sha, subject in commits:
+            short = sha[:7]
+            label = subject or short
+            lines.append(f"- [{label}](https://github.com/divengine/ways/commit/{sha})")
+    else:
+        lines.append("- No commits found.")
+    lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", default="")
+    parser.add_argument("--base-tag", default="")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument(
+        "--output",
+        default="",
+        help="Output file path. Defaults to releases/v<version>.md",
+    )
+    args = parser.parse_args()
+
+    version = args.version.strip() or get_version()
+    base = args.base_tag.strip()
+    if not base:
+        prev_version = get_previous_release_version(version)
+        if prev_version:
+            prev_tag = f"v{format_version(prev_version)}"
+            if tag_exists(prev_tag):
+                base = prev_tag
+            else:
+                base = get_base_from_previous_notes(prev_version)
+        if not base:
+            base = get_last_tag()
+    head = args.head.strip() or "HEAD"
+
+    output = args.output.strip()
+    if not output:
+        output = f"releases/v{version}.md"
+
+    out_path = (ROOT / output).resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing_description = load_existing_description_block(out_path)
+    notes = build_notes(version, base, head, existing_description)
+    out_path.write_text(notes, encoding="utf-8", newline="\n")
+
+    print(f"Release notes written to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/puppeteer.json
+++ b/scripts/puppeteer.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+}

--- a/src/ways.php
+++ b/src/ways.php
@@ -21,7 +21,7 @@ use RuntimeException;
  *
  * @package divengine/ways
  * @author  Rafa Rodriguez @rafageist [https://rafageist.com]
- * @version 3.0.0
+ * @version 2.5.0
  *
  * @link    https://divengine.org
  * @link    https://github.com/divengine/ways
@@ -55,7 +55,7 @@ class ways
 
     const PROPERTY_RULES = 'rules';
 
-    private static $__version = '3.0.0';
+    private static $__version = '2.5.0';
 
     private static $__way_var;
 
@@ -578,7 +578,7 @@ class ways
             $args = [];
             $pattern = trim($pattern);
 
-            if ($pattern === null || empty($pattern) || $pattern === '/') {
+            if ($pattern === '' || $pattern === '/') {
                 $pattern = $default_way;
             }
 

--- a/tests/WaysTest.php
+++ b/tests/WaysTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace divengine\tests;
+
+use divengine\ways;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class WaysTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->resetWaysState();
+        $_GET = [];
+        $_SERVER['argv'] = ['phpunit'];
+        $_SERVER['argc'] = 1;
+        unset($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'], $_SERVER['SERVER_SOFTWARE']);
+    }
+
+    public function testMatchesArgumentsInWays(): void
+    {
+        $args = [];
+
+        self::assertTrue(ways::match('/users/{id|is_int}', '/users/42', $args));
+        self::assertSame(['id' => '42'], $args);
+    }
+
+    public function testInvokesARegisteredClosureAndReturnsData(): void
+    {
+        ways::listen('get://hello/{name}', function (array $data, array $args): array {
+            return [
+                'message' => "Hello {$args['name']}",
+                'seed' => $data['seed'],
+            ];
+        });
+
+        $result = ways::invoke('get://hello/Ada', ['seed' => 'ways']);
+
+        self::assertSame('Hello Ada', $result['message']);
+        self::assertSame('ways', $result['seed']);
+        self::assertSame(1, ways::getTotalExecutions());
+    }
+
+    public function testBeforeRunHookCanUpdateControllerData(): void
+    {
+        ways::listen('/home', function (array $data): array {
+            return ['user' => $data['user']];
+        }, 'home');
+
+        ways::hook(DIV_WAYS_BEFORE_RUN, 'home', function (array $data): array {
+            $data['user'] = 'Peter';
+            return $data;
+        });
+
+        $result = ways::invoke('/home');
+
+        self::assertSame('Peter', $result['user']);
+    }
+
+    public function testRuleCanPreventControllerExecution(): void
+    {
+        ways::rule('deny', static fn (): bool => false);
+
+        ways::listen('/secret', function (): array {
+            return ['executed' => true];
+        }, [
+            ways::PROPERTY_ID => 'secret',
+            ways::PROPERTY_RULES => ['deny'],
+        ]);
+
+        $result = ways::invoke('/secret');
+
+        self::assertArrayNotHasKey('executed', $result);
+        self::assertSame(0, ways::getTotalExecutions());
+    }
+
+    private function resetWaysState(): void
+    {
+        $class = new ReflectionClass(ways::class);
+        $defaults = $class->getDefaultProperties();
+
+        foreach ($class->getProperties() as $property) {
+            if (!$property->isStatic()) {
+                continue;
+            }
+
+            $property->setAccessible(true);
+            $property->setValue(null, $defaults[$property->getName()] ?? null);
+        }
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require dirname(__DIR__) . '/vendor/autoload.php';


### PR DESCRIPTION
This pull request introduces a comprehensive set of improvements to project infrastructure, documentation, and release automation for Div PHP Ways. The most significant changes include adding project-specific CI workflows, improving and restructuring documentation, and establishing a robust release process with automated PDF documentation and release note requirements.

**Continuous Integration and Quality Assurance:**

- Added GitHub Actions workflows for running PHPUnit tests (`.github/workflows/tests.yml`), static analysis with PHPStan (`.github/workflows/phpstan.yml`), and automated release builds with PDF documentation and artifact uploads (`.github/workflows/release.yml`). [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR1-R32) [[2]](diffhunk://#diff-73a1d6ddd0eabb7e1349cdb83b76ff10f29f9e4fe316c0cd29495174181f4546R1-R32) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R151)
- Introduced a PHPStan configuration file (`phpstan.neon`) and a PHPUnit configuration file (`phpunit.xml`) tailored to the project. [[1]](diffhunk://#diff-0361f0c81f363476ddc6f44ab36fcbe66ee685d5f4c2a46b054924591544b766R1-R6) [[2]](diffhunk://#diff-ae310e922c85656813bd29d9f3c9a1b87c8aaa83d924813a5b91c67b7abb3cb9R1-R16)

**Documentation Improvements:**

- Major rewrite and simplification of `README.md` to clarify the "ways" concept, provide concise usage examples, and document installation, rules, CLI usage, and license.
- Added and reordered documentation files for book/PDF generation, including a new book order file (`docs/book-order.txt`) and improved navigation in the Markdown docs. [[1]](diffhunk://#diff-4b4c2814b5ab095af1f8c70ed0fdda8dcf0e21191361ca12453ddcbe623f40e3R1-R6) [[2]](diffhunk://#diff-91f37de4a19a34f7aa74d2ffa3ca18cb5749c7b68c272eb409b99be74936a586L4-R4)
- Added a stylized HTML back page for the generated documentation PDF (`scripts/back.html`).

**Release Process Automation:**

- Established a release notes policy and template in `releases/README.md`, requiring a Markdown file per release and providing a script for generating drafts.
- Added an initial release notes file for v2.5.0 (`releases/v2.5.0.md`).
- Updated `.gitattributes` to exclude development and CI files from release archives.

**Grouped summary of the most important changes:**

**1. CI/CD and Quality Automation**
- Added GitHub Actions workflows for PHPUnit testing, PHPStan static analysis, and automated release builds with PDF documentation and artifact uploads. (`.github/workflows/tests.yml`, `.github/workflows/phpstan.yml`, `.github/workflows/release.yml`) [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR1-R32) [[2]](diffhunk://#diff-73a1d6ddd0eabb7e1349cdb83b76ff10f29f9e4fe316c0cd29495174181f4546R1-R32) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R151)
- Added project-specific PHPStan and PHPUnit configuration files for static analysis and test execution. (`phpstan.neon`, `phpunit.xml`) [[1]](diffhunk://#diff-0361f0c81f363476ddc6f44ab36fcbe66ee685d5f4c2a46b054924591544b766R1-R6) [[2]](diffhunk://#diff-ae310e922c85656813bd29d9f3c9a1b87c8aaa83d924813a5b91c67b7abb3cb9R1-R16)

**2. Documentation Overhaul**
- Rewrote and reorganized `README.md` for clarity, concise examples, and improved onboarding.
- Improved documentation structure and navigation with a new book order file and updated Markdown references. (`docs/book-order.txt`, `docs/Div PHP Ways.md`) [[1]](diffhunk://#diff-4b4c2814b5ab095af1f8c70ed0fdda8dcf0e21191361ca12453ddcbe623f40e3R1-R6) [[2]](diffhunk://#diff-91f37de4a19a34f7aa74d2ffa3ca18cb5749c7b68c272eb409b99be74936a586L4-R4)
- Added a custom HTML back page for the generated documentation PDF. (`scripts/back.html`)

**3. Release Management**
- Introduced a release notes policy and automation script, requiring Markdown release notes for each version and providing a template. (`releases/README.md`)
- Added an example release notes file for v2.5.0. (`releases/v2.5.0.md`)
- Updated `.gitattributes` to exclude development and CI files from release archives.
- Create release workflow for automated versioning and artifact uploads
- Add tests workflow for PHPUnit integration
- Introduce book order file for documentation structure
- Configure PHPStan for static analysis
- Set up PHPUnit configuration file
- Add release notes template and initial release note for v2.5.0
- Implement HTML templates for cover and back pages of the documentation
- Develop PDF building script with support for Mermaid diagrams
- Generate release notes script to automate release documentation
- Add Puppeteer configuration for HTML to PDF rendering
- Implement unit tests for the Ways routing engine
- Create bootstrap file for test environment setup